### PR TITLE
Add placeholder for TransportationCamp NYC 2015

### DIFF
--- a/events/nyc-2015/index.md
+++ b/events/nyc-2015/index.md
@@ -1,0 +1,18 @@
+---
+comments: false
+date: 2015-11-14 12:00:00+00:00
+layout: event
+slug: "nyc-2015"
+title: TransportationCamp NYC 2015
+published: false
+---
+
+## General Info
+
+Mark your calendars for Saturday, November 14, 2015: 
+**TransportationCamp NYC 2015** will take place at [City College of New York](http://www.ccny.cuny.edu/).
+
+Registration is not yet open. Stay tuned to [@TranspoCamp](https://twitter.com/transpocamp) 
+and this page to be notified when tickets become available.
+ 
+ 


### PR DESCRIPTION
This is just a placeholder so we have a live URL to work with - more details are expected within the next week, when we'll be putting out our first public announcement.
