### PR TITLE
Fix egregious typos, including "Transportation Camp" and "Open Plans".

### DIFF
--- a/_posts/2011-02-14-travel-stipends.markdown
+++ b/_posts/2011-02-14-travel-stipends.markdown
@@ -16,6 +16,6 @@ Thinking of attending TransportationCamp but worried about lodging or travel exp
 
 A very limited number of travel stipends (of $500 each) are available to **students, non-profit or government representatives** who would like to attend TransportationCamp.
 
-If you would like to request a travel stipend, please email janetti AT openplans DOT org, with the subject line "Transportation Camp Travel Stipend Request."  Assistance requests for both EAST and WEST events are available until filled, on a first-come, first-serve basis.
+If you would like to request a travel stipend, please email janetti AT openplans DOT org, with the subject line "TransportationCamp Travel Stipend Request."  Assistance requests for both EAST and WEST events are available until filled, on a first-come, first-serve basis.
 
 We can't wait to see you at TransportationCamp!

--- a/_posts/2011-03-10-gearing-up-for-transportationcamp-west.markdown
+++ b/_posts/2011-03-10-gearing-up-for-transportationcamp-west.markdown
@@ -12,7 +12,7 @@ categories:
 
 As the [buzz continues](http://twitter.com/#!/search/%23transpo) from TransportationCamp East, we're getting ready for the West edition. **TransportationCamp West** is coming to San Francisco on Saturday and Sunday, March 18th and 20th.
 
-Find venue details and the overall structure of the day on the [Schedule](http://transportationcamp.org/west) page. The actual sessions will be decided on the day, read our [Essential Guide to Transportation Camp](http://transportationcamp.org/2011/02/how-transportationcamp-works-the-essential-guide/) for details.
+Find venue details and the overall structure of the day on the [Schedule](http://transportationcamp.org/west) page. The actual sessions will be decided on the day, read our [Essential Guide to TransportationCamp](http://transportationcamp.org/2011/02/how-transportationcamp-works-the-essential-guide/) for details.
 
 
   

--- a/_posts/2012-01-22-so-this-one-time-at-transportation-camp.markdown
+++ b/_posts/2012-01-22-so-this-one-time-at-transportation-camp.markdown
@@ -4,7 +4,7 @@ comments: true
 date: 2012-01-22 01:39:45+00:00
 layout: post
 slug: so-this-one-time-at-transportation-camp
-title: '"So this one time, at Transportation Camp..."'
+title: '"So this one time, at TransportationCamp..."'
 wordpress_id: 1503
 categories:
 - Latest News

--- a/_posts/2013-10-31-transportationcamp-is-returning-to-dc-in-january.markdown
+++ b/_posts/2013-10-31-transportationcamp-is-returning-to-dc-in-january.markdown
@@ -10,11 +10,11 @@ categories:
 - Latest News
 ---
 
-The[ 3rd Annual TransportationCamp Washington DC](http://transportationcamp.org/) will be held on Saturday, January 11, 2014. [Click here to register](https://transpocampdc14.eventbrite.com/).
+The [3rd Annual TransportationCamp Washington DC](http://transportationcamp.org/) will be held on Saturday, January 11, 2014. [Click here to register](https://transpocampdc14.eventbrite.com/).
 
-Following on the success of [previous Transportation Camps](http://transportationcamp.org/dc/), TransportationCamp DC '14 will continue to expand the opportunities we have to improve mobility through recent advances in technology, such as web 2.0, mobile computing, open source software, open data and APIs, and spatial analysis. The conference will also examine ways to build connections between disparate innovators in public administration, transportation operations, information design, and software engineering.
+Following on the success of [previous TransportationCamps](http://transportationcamp.org/dc/), TransportationCamp DC '14 will continue to expand the opportunities we have to improve mobility through recent advances in technology, such as web 2.0, mobile computing, open source software, open data and APIs, and spatial analysis. The conference will also examine ways to build connections between disparate innovators in public administration, transportation operations, information design, and software engineering.
 
-TransporationCamp attendees are submitting ideas on the Twitter [collaboration site.](http://ideas.transportationcamp.org). Some fascinating discussions are underway, and the list keeps growing. Any of those topics can become a session at Camp, if someone is willing to lead it.
+TransporationCamp attendees are submitting ideas on the Twitter [collaboration site](http://ideas.transportationcamp.org). Some fascinating discussions are underway, and the list keeps growing. Any of those topics can become a session at Camp, if someone is willing to lead it.
 
 Review the list and help the best topics become sessions. Leave responses and use the “support this” button to let others know what topics are hot. If something grabs your attention or gets you worked up, blog about it and post a link.
 
@@ -22,5 +22,3 @@ Review the list and help the best topics become sessions. Leave responses and us
 TransportationCamp will be on Saturday before the start of the [Transportation Research Board 93rd Annual Meeting](http://www.trb.org/AnnualMeeting2014/AnnualMeeting2014.aspx).
 
 We're excited to be hosted by the GMU School of Public Policy, at GMU Founders Hall, 3351 Fairfax Drive, Arlington, VA 22201.
-
-[More details](http://transportationcamp.org/transportationcamp-dc-2014/).

--- a/_posts/2013-12-09-tom-fairchild.md
+++ b/_posts/2013-12-09-tom-fairchild.md
@@ -19,9 +19,9 @@ It's through a variety of programs that include outreach to employers to make su
 
 The interest of the government in these types of initiatives is highway road congestion, but now our research and analysis goes beyond that to looking the health implications, improvements, outcomes, and other sustainability natures of our programs.
 
-Additionally we're involved in the development of new types of tools to make it easy for people to get out of their cars. This includes technology tools--of course our involvement in Transportation Camp--and we do a variety of hack nights, and we're sponsoring the deployment of OneBusAway here in the DC region.
+Additionally we're involved in the development of new types of tools to make it easy for people to get out of their cars. This includes technology tools--of course our involvement in TransportationCamp--and we do a variety of hack nights, and we're sponsoring the deployment of OneBusAway here in the DC region.
 
-We are also engaged in a lot of collaborations with other organizations that have overlapping mission statements like Open Plans and a variety of other groups even that are involved in housing or other areas. It's finding that common space so we can work together to make things better.
+We are also engaged in a lot of collaborations with other organizations that have overlapping mission statements like OpenPlans and a variety of other groups even that are involved in housing or other areas. It's finding that common space so we can work together to make things better.
 
 **What's the most exciting thing that Mobility Lab is working on right now?**
 
@@ -31,7 +31,7 @@ That has been deployed now in several cities around the country including New Yo
 
 So OneBusAway will bring it all together into one space and I think it will really make our development of tools so much better and we'll be able to take advantage of some of the open source tools that have already been developed on that platform.
 
-**As you know Transportation Camp is all about the intersection of technology and transportation and this year we're trying to advance the level of conversation about tech's role in the future of transportation both at the event and hopefully more widely. As you think about the future, what's most interesting to you right now on the technology side of transportation?**
+**As you know TransportationCamp is all about the intersection of technology and transportation and this year we're trying to advance the level of conversation about tech's role in the future of transportation both at the event and hopefully more widely. As you think about the future, what's most interesting to you right now on the technology side of transportation?**
 
 I think we have a long way to go. My belief is that individuals who occupy our most exciting cities are largely shunning their automobile. And when it comes to transportation, everyone has preferences. It's like in food; some people like Thai, some people like Italian, whatever.
 
@@ -58,8 +58,8 @@ And at a certain point someone might say, "Forget about that agency because it's
 
 You're right and there need to be places where everyone can get this information and also say that we need to be aware that some of those options are more readily available to everyone than others as well.
 
-Not everyone is going to jump in Uber Car and that will probably never change. But even Bikeshare, you have to have credit in order to get a bike currently for most of the citizens around the world. So there are some obstacles on that side.
-But from an information standpoint, smart phones are obviously very important but there's also an open source project that we developed here at Mobility Lab that's been taken on by a commercial developer to take to the marketplace called Transit Screen.
+Not everyone is going to jump in Uber car and that will probably never change. But even Bikeshare, you have to have credit in order to get a bike currently for most of the citizens around the world. So there are some obstacles on that side.
+But from an information standpoint, smart phones are obviously very important but there's also an open source project that we developed here at Mobility Lab that's been taken on by a commercial developer to take to the marketplace called TransitScreen.
 
 That's a project where all of the options are displayed and put up in locations where individuals can see them. This might be at Metro stations. They might be in lobbies of buildings. They could be in store windows. It could be in a whole variety of places where anyone would be able to get that information.
 
@@ -73,9 +73,9 @@ The health implications of being on a bike, obviously that's a great activity an
 
 Will cars be considered the cigarettes of tomorrow? I don't know, but I think we're heading in that direction where we can hopefully at some point have a reasonable conversation that cars are very unhealthy for our country and for the world.
 
-**January 11th is coming up fast. What advice do you have for a new Transportation Camp participant to get the most out of the day?**
+**January 11th is coming up fast. What advice do you have for a new TransportationCamp participant to get the most out of the day?**
 
-First, be there.  I think that the best way to understand and to get in the spirit of the game is to just arrive and come realizing that we're all in this together. There are a lot of folks that are coming in together from around the country and around the world with it being the day before TRB begins. People arrive in the DC region from everywhere to take advantage of the activities around TRB with Transportation Camp being one of them.
+First, be there.  I think that the best way to understand and to get in the spirit of the game is to just arrive and come realizing that we're all in this together. There are a lot of folks that are coming in together from around the country and around the world with it being the day before TRB begins. People arrive in the DC region from everywhere to take advantage of the activities around TRB with TransportationCamp being one of them.
 
 So first come, but secondly come with your ideas and come with the idea of participating. I know that we humans are sometimes reticent to just dive into an unknown crowd, but everyone is coming into an unknown crowd here and it's fun.
 

--- a/_posts/2013-12-16-kari-watkins.md
+++ b/_posts/2013-12-16-kari-watkins.md
@@ -66,8 +66,8 @@ The older folks don't tend to own the smartphone. When you've got this grandma, 
 
 We need to think from a user‑centered design perspective. Thinking about some of the different persons who are being missed and making sure that we're still getting information to them as they need to have it.
 
-<b>January 11th is coming up soon. What advice do you have for someone coming to Transportation Camp for the first time, to get the most out of the day?</b>
+<b>January 11th is coming up soon. What advice do you have for someone coming to TransportationCamp for the first time, to get the most out of the day?</b>
 
-Jump in with two feet, and don't be afraid to really participate, even if you feel you are younger. It's all about discussion, so this is a chance to actually to be an active participant. I would say to older participants--because there were some jokes at the last Transportation Camp among some of my crowd as well as older--they need the older professionals in transportation at a place like Transportation Camp. Jump in and don't be afraid to participate because you're a little bit less technology savvy or something like that. They've got so much to add to this group, and you can really get a great vibe going.
+Jump in with two feet, and don't be afraid to really participate, even if you feel you are younger. It's all about discussion, so this is a chance to actually to be an active participant. I would say to older participants--because there were some jokes at the last TransportationCamp among some of my crowd as well as older--they need the older professionals in transportation at a place like TransportationCamp. Jump in and don't be afraid to participate because you're a little bit less technology savvy or something like that. They've got so much to add to this group, and you can really get a great vibe going.
 
 (<i>This interview has been edited for clarity and length.</i>)

--- a/_posts/2014-01-07-Kevin-Webb.md
+++ b/_posts/2014-01-07-Kevin-Webb.md
@@ -27,7 +27,7 @@ What's been really interesting is that the data that has been created largely to
 
 We're seeing that the data that was created for the public purposes are actually surpassing this other data and allowing us to really rethink the way that we use information tools to drive these sorts of problems. That's allowing us to expand the scope of what people can do with computer simulation and planning.
 
-<strong>Transportation Camp is all about the intersection of technology and transportation. As you're thinking about your work and the future of the field, what's most interesting to you right now on the technology side? </strong>
+<strong>TransportationCamp is all about the intersection of technology and transportation. As you're thinking about your work and the future of the field, what's most interesting to you right now on the technology side? </strong>
 
 It's definitely related to that notion of using it for public planning purposes. What's going on that's actually really exciting is people are starting to realize that these data systems are actually fundamentally part of the infrastructure that's being built as well.
 
@@ -63,7 +63,7 @@ The leadership in the U.S. has been a bit more conservative, in the sense of say
 
 That's something all of us in the community are working to change, but it's been a long process.
 
-<strong>Is this what you want to talk about at Transportation Camp? What are some of the sessions you want to see?</strong>
+<strong>Is this what you want to talk about at TransportationCamp? What are some of the sessions you want to see?</strong>
 
 It's certainly one of the things I want to talk about. We have an opportunity every year to come to DC as a community of people interested in this stuff and really have a dialogue about things that matter, not just at a local level or for individual communities across the country, but actually talk about it from a national policy perspective, and some of those people are in the room when we do this.
 
@@ -75,7 +75,7 @@ That's where we are as a group, right now; very much focused on the analysis too
 
 That's been something that's been really exciting to see over the last year or so; that community that's starting to gel around very specific questions. We're doing work now with members of it, but we want to make sure the dialogue is open and inclusive, so that people who are interested in adopting these sorts of questions and conversations in their local community understand what's going on with other players, and willing to coordinate their activity.
 
-<strong>For</strong> <strong>people who haven't been to Transportation Camp before, what advice would you have for them, coming to their first one?</strong>
+<strong>For</strong> <strong>people who haven't been to TransportationCamp before, what advice would you have for them, coming to their first one?</strong>
 
 Bring something you care about to share. The most important part of it is that everyone shows up with ideas and things that they are passionate about, and puts them out there.
 
@@ -83,8 +83,4 @@ It's not enough just to expect that you're going to hear interesting things. You
 
 People, even from outside the technology community or outside the traditional norms of transportation, still have a lot to offer in terms of helping shape the conversation.
 
-(T<em>his interview has been edited for clarity and length.</em>)
-
-&nbsp;
-
-&nbsp;
+(<em>This interview has been edited for clarity and length.</em>)

--- a/_posts/2014-01-09-Chris-Pangilinan.md
+++ b/_posts/2014-01-09-Chris-Pangilinan.md
@@ -20,7 +20,7 @@ We are taking roadway improvements, and traffic signal improvements, and designi
 <strong>How far along are you in that program? Is it new, or have you been doing it for a while?</strong>
 
 It started back in '06 as a long planning project, and we're now just clearing the environmental impact report. Should be, hopefully if everything goes well with funding, we'll be beginning to implement it next year. Now we're in the throes of public process and design. It’s going to be a one to four‑year process of actual construction and build‑out.
-As you know, Transportation Camp is about the intersection of technology and transportation, and we want to advance the level of that conversation.
+As you know, TransportationCamp is about the intersection of technology and transportation, and we want to advance the level of that conversation.
 
 <strong>As you think about your work and about the future of the field in general, what's most interesting to you right now on the technology side of transportation?</strong>
 

--- a/_posts/2014-01-29-transportationcamp-is-coming-to-new-england.md
+++ b/_posts/2014-01-29-transportationcamp-is-coming-to-new-england.md
@@ -11,4 +11,4 @@ categories:
 
 Join us for the first TransportationCamp in the New England area. The unconference will be held in Boston on Saturday April 5th, 2014, hosted by MIT. We’re looking forward to a day of discussion and examination of transportation planning, innovation, and technology. <a href="http://www.eventbrite.com/e/transportation-camp-new-england-14-tickets-10281011783">Register today</a>.
 
-Read about the previous Transportation Camps in DC, San Francisco, and Atlanta <a href=}http://transportationcamp.org/>here</a>.
+Read about the previous TransportationCamps in DC, San Francisco, and Atlanta <a href="http://transportationcamp.org/">here</a>.

--- a/events/dc-2014/index.markdown
+++ b/events/dc-2014/index.markdown
@@ -22,7 +22,7 @@ Review the list and help the best topics become sessions. Leave responses and us
 ## When and where
 The 3rd Annual TransportationCamp Washington DC will be held on Saturday, January 11, 2014. [Click here to register](https://transpocampdc14.eventbrite.com/).
 
-Following on the success of [previous Transportation Camps](http://transportationcamp.org/dc/), TransportationCamp DC '14 will continue to expand the opportunities we have to improve mobility through recent advances in technology, such as web 2.0, mobile computing, open source software, open data and APIs, and spatial analysis. The conference will also examine ways to build connections between disparate innovators in public administration, transportation operations, information design, and software engineering.
+Following on the success of [previous TransportationCamps](http://transportationcamp.org/dc/), TransportationCamp DC '14 will continue to expand the opportunities we have to improve mobility through recent advances in technology, such as web 2.0, mobile computing, open source software, open data and APIs, and spatial analysis. The conference will also examine ways to build connections between disparate innovators in public administration, transportation operations, information design, and software engineering.
 
 
 The event will be on Saturday before the start of the [Transportation Research Board 93rd Annual Meeting](http://www.trb.org/AnnualMeeting2014/AnnualMeeting2014.aspx).
@@ -40,11 +40,11 @@ The location is easy to get to:
   * Two Capital Bikeshare stations are also within two blocks, at Virginia Square Metro and at Fairfax Dr/Wilson Blvd.
 
 
-  * Metro bus 38B runs from K St, NW and Georgetown.
+  * Metrobus 38B runs from K St, NW and Georgetown.
 
 
-Here's more info including[ parking and a map of the campus](http://info.gmu.edu/Maps/ArlingtonMap12.pdf).
+Here's more info including [parking and a map of the campus](http://info.gmu.edu/Maps/ArlingtonMap12.pdf).
 
 After wrapping up the day at 5pm we will go for drinks at a location nearby, TBD.
 
-TransportationCamp DC '14 is organized by [Open Plans](http://openplans.org/), [Conveyal](http://www.conveyal.com/), [Mobility Lab](http://mobilitylab.org/), [Young Professionals in Transportation](http://yptransportation.org/), [Transportation Research Board](http://www.trb.org/Main/Home.aspx), and the [GMU School of Public Policy](http://policy.gmu.edu/). Special thanks go to [American Association of State Highway and Transportation Officials](http://www.transportation.org/Pages/default.aspx) for providing scholarships for students.
+TransportationCamp DC '14 is organized by [OpenPlans](http://openplans.org/), [Conveyal](http://www.conveyal.com/), [Mobility Lab](http://mobilitylab.org/), [Young Professionals in Transportation](http://yptransportation.org/), [Transportation Research Board](http://www.trb.org/Main/Home.aspx), and the [GMU School of Public Policy](http://policy.gmu.edu/). Special thanks go to [American Association of State Highway and Transportation Officials](http://www.transportation.org/Pages/default.aspx) for providing scholarships for students.

--- a/events/dc-2015/index.markdown
+++ b/events/dc-2015/index.markdown
@@ -4,11 +4,11 @@ comments: false
 date: {}
 layout: event
 slug: "dc-2015"
-title: Transportation Camp DC 2015
+title: TransportationCamp DC 2015
 wordpress_id: 1623
 published: true
 ---
-The 4th Annual Transportation Camp Washington DC was held on Saturday, January 10, 2015, the day before the start of the [Transportation Research Board 94th Annual Meeting](http://www.trb.org/AnnualMeeting2015/AnnualMeeting2015.aspx). We were hosted by the [George Mason University School of Policy, Government, and International Affairs](http://spgia.gmu.edu/), at [Founders Hall](http://arlington.gmu.edu/).
+The 4th Annual TransportationCamp Washington DC was held on Saturday, January 10, 2015, the day before the start of the [Transportation Research Board 94th Annual Meeting](http://www.trb.org/AnnualMeeting2015/AnnualMeeting2015.aspx). We were hosted by the [George Mason University School of Policy, Government, and International Affairs](http://spgia.gmu.edu/), at [Founders Hall](http://arlington.gmu.edu/).
 
 Registration was at [transportationcamp2015dc.eventbrite.com](https://transportationcamp2015dc.eventbrite.com). We had 440 attendees.
 
@@ -35,7 +35,7 @@ Our sponsors are organizing panel discussions that will be part of the first per
 ## Details
 We open registration and a light breakfast at 8:30am. Lunch and breakfast are included with your registration. Camp starts promptly with Reveille at 9:00am. The schedule will have four periods of breakout sessions, spread out among ten rooms. We will have 3-4 pre-set panels, with topics to be announced later. The program wraps up at 5:00pm, after which everyone is invited to a local pub for a Post-Camp Happy Hour!
 
-You can read about last year's Transportation Camp on [mobilitylab.org](http://mobilitylab.org/tag/transportationcamp/), and visit the sites for previous years: [2012](http://transportationcamp.org/events/dc/), [2013](http://transportationcamp.org/events/dc-2013/), and [2014](http://transportationcamp.org/events/dc-2014/). 
+You can read about last year's TransportationCamp on [mobilitylab.org](http://mobilitylab.org/tag/transportationcamp/), and visit the sites for previous years: [2012](http://transportationcamp.org/events/dc/), [2013](http://transportationcamp.org/events/dc-2013/), and [2014](http://transportationcamp.org/events/dc-2014/). 
 
 We'll be returning this year to GMU Founders Hall, at 3351 Fairfax Drive, Arlington, VA 22201. The campus is easy to get to:
 
@@ -49,4 +49,4 @@ Here's a map of the [Arlington campus](http://info.gmu.edu/Maps/ArlingtonMap14.p
 
 If you're in town early, the [Transportation Techies](http://www.meetup.com/Transportation-Techies/) meetup group will have a meetup on Thursday, January 8 called [Autotopia Night](http://www.meetup.com/Transportation-Techies/events/213357602/), about traffic/parking and technology (contact the group if interested in presenting an app or data visualization). More info via [@techiesdc](https://twitter.com/techiesdc).
 
-TransportationCamp DC '15 is organized by [Mobility Lab](http://mobilitylab.org/), [TransitCenter](http://transitcenter.org/), [Open Plans](http://openplans.org/), the [GMU School of Policy, Government, and International Affairs](http://spgia.gmu.edu/), the [American Association of State Highway and Transportation Officials](http://www.transportation.org/), the [Institute of Transportation Engineers](http://www.ite.org/), [Young Professionals in Transportation](http://yptransportation.org/), and [Transportation Research Board](http://www.trb.org/).
+TransportationCamp DC '15 is organized by [Mobility Lab](http://mobilitylab.org/), [TransitCenter](http://transitcenter.org/), [OpenPlans](http://openplans.org/), the [GMU School of Policy, Government, and International Affairs](http://spgia.gmu.edu/), the [American Association of State Highway and Transportation Officials](http://www.transportation.org/), the [Institute of Transportation Engineers](http://www.ite.org/), [Young Professionals in Transportation](http://yptransportation.org/), and [Transportation Research Board](http://www.trb.org/).

--- a/events/dc-2015/schedule.html
+++ b/events/dc-2015/schedule.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html onkeypress="checkInput(event)">
 <head>
-<title>Transportation Camp 2015 DC Schedule</title>
+<title>TransportationCamp 2015 DC Schedule</title>
 <base target="_blank">
 <style> 
 body {  
@@ -29,7 +29,7 @@ a:hover {
 </style> 
 </head>
 <body>
-<h1>Transportation Camp 2015 DC Schedule</h1>
+<h1>TransportationCamp 2015 DC Schedule</h1>
 <p>
 <table>
 <tr><td align=right >8:30am</td><td>Doors open, breakfast</td></tr>

--- a/events/dc-2015/schedule.md
+++ b/events/dc-2015/schedule.md
@@ -1,4 +1,4 @@
-#Transportation Camp 2015 DC Schedule
+#TransportationCamp 2015 DC Schedule
 ```
 8:30am Doors open, breakfast
 9:30am Welcome & introductions

--- a/events/dc-2016/index.markdown
+++ b/events/dc-2016/index.markdown
@@ -4,16 +4,16 @@ comments: false
 date: {}
 layout: event
 slug: "dc-2016"
-title: Transportation Camp DC 2016 
+title: TransportationCamp DC 2016 
 published: true
 ---
-Mark your calendars for the 5th annual Transportation Camp in Washington, DC: [Mobility Lab](http://mobilitylab.org/) is putting together plans to hold this event on Saturday, January 9, 2016, the day before the start of the [Transportation Research Board 95th Annual Meeting](http://www.trb.org/AnnualMeeting/AnnualMeeting.aspx). 
+Mark your calendars for the 5th annual TransportationCamp in Washington, DC: [Mobility Lab](http://mobilitylab.org/) is putting together plans to hold this event on Saturday, January 9, 2016, the day before the start of the [Transportation Research Board 95th Annual Meeting](http://www.trb.org/AnnualMeeting/AnnualMeeting.aspx). 
 
-Transportation Camp is an “unconference” that brings together transportation professionals, technologists, and others interested in the intersection of urban transportation and technology. Want to learn more about unconferences? Here's our handy guide: [How TransportationCamp works: the essential guide](http://transportationcamp.org/2011/02/how-transportationcamp-works-the-essential-guide/).
+TransportationCamp is an “unconference” that brings together transportation professionals, technologists, and others interested in the intersection of urban transportation and technology. Want to learn more about unconferences? Here's our handy guide: [How TransportationCamp works: the essential guide](http://transportationcamp.org/2011/02/how-transportationcamp-works-the-essential-guide/).
 
-Bring your ideas to expand the opportunities we have to improve mobility through recent advances in technology, such as web 2.0, mobile computing, open source software, open data and APIs, and spatial analysis. Participants will also examine ways to build connections between disparate innovators in public administration, transportation operations, information design, and software engineering. 
+Bring your ideas to expand the opportunities we have to improve mobility through recent advances in technology, such as Web 2.0, mobile computing, open source software, open data and APIs, and spatial analysis. Participants will also examine ways to build connections between disparate innovators in public administration, transportation operations, information design, and software engineering. 
 
 Learn about last year's event by browsing the hackpads linked to from the [schedule](http://transportationcamp.org/events/dc-2015/schedule.html) or via [tcamp2015dc.hackpad.com](https://tcamp2015dc.hackpad.com/). Pages for previous years: [2012](http://transportationcamp.org/events/dc/), [2013](http://transportationcamp.org/events/dc-2013/), [2014](http://transportationcamp.org/events/dc-2014/), and [2015](http://transportationcamp.org/events/dc-2015/). 
 
-Stay tuned to [@transpocamp](https://twitter.com/transpocamp) (and the [#transpo16](https://twitter.com/search?q=%23transpo16) hashtag) for news about this event and other Transportation Camps as they are announced.
+Stay tuned to [@transpocamp](https://twitter.com/transpocamp) (and the [#transpo16](https://twitter.com/search?q=%23transpo16) hashtag) for news about this event and other TransportationCamps as they are announced.
  

--- a/events/east/index.markdown
+++ b/events/east/index.markdown
@@ -8,7 +8,7 @@ title: East - NYC
 wordpress_id: 77
 ---
 
-TransportationCamp East was held in **New York City **on **Saturday March 5 and Sunday March 6, 2011. **
+TransportationCamp East was held in **New York City** on **Saturday March 5 and Sunday March 6, 2011**.
 
 We'd like to thank the group of [partners and advisors](http://transportationcamp.org/partners-and-advisors/) for their support in organizing this event.
 
@@ -51,7 +51,7 @@ Afternoon tours, [details here](http://transportationcamp.org/2011/02/join-a-tou
 #### 9am
 
 
-** Morning program**
+**Morning program**
 
 
 

--- a/events/new-england-2014/index.markdown
+++ b/events/new-england-2014/index.markdown
@@ -11,7 +11,7 @@ published: true
 
 The 1st Annual TransportationCamp New England will be held on Saturday, April 5, 2014.
 
-Following on the success of previous Transportation Camps, TransportationCamp New England '14 will continue to examine ways to build connections between disparate innovators in public administration, transportation planning, transportation operations, information design, and software engineering.
+Following on the success of previous TransportationCamps, TransportationCamp New England '14 will continue to examine ways to build connections between disparate innovators in public administration, transportation planning, transportation operations, information design, and software engineering.
 
 You can [register here](http://www.eventbrite.com/e/transportation-camp-new-england-14-tickets-10281011783). Share your session ideas on our collaborative [ideas site](http://ideas.transportationcamp.org). Follow us on Twitter for the latest updates, @TranspoCampNE. You can also like us on [Facebook](https://www.facebook.com/pages/TransportationCamp-New-England/219391578269518).
 
@@ -27,8 +27,8 @@ TransportationCamp New England '14 is organized by [Cambridge Systematics](http:
 
 If you are interested becoming a sponsor of TransportationCamp New England '14, please read our [sponsorship information](https://www.dropbox.com/s/cxxtdk95gr2a5jw/Transpocamp%20Flyer_Sponsor%20NE%202014.pdf).
 
-Transportation Camp New England 2014 is collaborating with the 37 Billion Mile Data Challenge.  This is a month-long challenge to explore anonymous vehicle-use data and discover insights that can help the Commonwealth build a model, estimated mileage, fuel efficiency of every registered vehicle in MA, as well as vehicles per household and green house gas emissions.
+TransportationCamp New England 2014 is collaborating with the 37 Billion Mile Data Challenge.  This is a month-long challenge to explore anonymous vehicle-use data and discover insights that can help the Commonwealth build a model, estimated mileage, fuel efficiency of every registered vehicle in MA, as well as vehicles per household and green house gas emissions.
 
 Participants are encouraged to submit data-driven visualizations, infographics, maps, web tools to answer driving questions about transportation, energy, and land use. The most compelling entries will receive cash prizes, Zipcar memberships, Hubway memberships, pre-loaded Charlie Cards, and more. The submission period closes April 19,2014 and winners announced by May 1st.
 
-For more information on the datathon [go here](http://www.37billionmilechallenge.org). Groups involved in the datathon will be presenting their ideas at Transportation Camp New England.
+For more information on the datathon [go here](http://www.37billionmilechallenge.org). Groups involved in the datathon will be presenting their ideas at TransportationCamp New England.

--- a/events/new-england-2015/index.markdown
+++ b/events/new-england-2015/index.markdown
@@ -8,7 +8,7 @@ title: TransportationCamp NE 2015
 wordpress_id: 1623
 published: true
 ---
-<a href="bFD0ljslwL.jpeg"><img src="bFD0ljslwLsmall.jpeg" width=241 height=160 align=right ></a>The 2nd Annual Transportation Camp New England will be held on Saturday, April 11, 2015. 
+<a href="bFD0ljslwL.jpeg"><img src="bFD0ljslwLsmall.jpeg" width=241 height=160 align=right ></a>The 2nd Annual TransportationCamp New England will be held on Saturday, April 11, 2015. 
 
 Following on the success of last year's event, TransportationCamp New England 2015 will continue to foster open conversation and collaboration between all parties interested in mobility and the radical changes the near-future promises in transportation.
 
@@ -59,7 +59,7 @@ Many thanks to our sponsors:
 <img src="sponsor-neite.png" width=160 height=80 > <img src="sponsor-zipcar.png" width=160 height=80 > <img src="sponsor-iBiz.png" width=160 height=80 ><br><img src="sponsor-Kinisi.png" width=120 height=120 ><br>
 <img src="sponsor-ecolane.png" width=120 height=120 > <img src="sponsor-cartodb.png" width=200 height=80 >   
 
-Transportation Camp New England 2015 is organized by Cambridge Systematics, in partnership with Mobility Lab, MIT, and the Boston Chapter of Young Professionals in Transportation.
+TransportationCamp New England 2015 is organized by Cambridge Systematics, in partnership with Mobility Lab, MIT, and the Boston Chapter of Young Professionals in Transportation.
 
 <img src="organizer-camsys.png" width=494 height=120 ><br>
 <img src="organizer-mit.png" width=167 height=86 > &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <img src="organizer-MobilityLab.png" width=120 height=120 > &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <img src="organizer-ypt.png" width=120 height=120 >

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@ title: TransportationCamp
     
     <p>Major themes include open data, best practices and technical challenges, ways to lower the cost of technology for transportation agencies, and creative new approaches to addressing transportation issues.</p>
     
-    <h4>History of Transportation Camp</h4>
+    <h4>History of TransportationCamp</h4>
 
     <p>TransportationCamp, the trailblazing transportation “unconference,” was first organized by 
     <a href="http://openplans.org/">OpenPlans</a> with 


### PR DESCRIPTION
This PR fixes all instances of "Transportation Camp" and "Open Plans" (except in link titles, where the title of the linked page is itself wrong).  It's important that we respect our brand and others' brands, and consistent spelling goes a long way.

There is also some minor markup cleanup in here, but there is still more markup cleanup to be done.
