### PR TITLE
Markup fixes in preparation for changing Markdown engine to kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 name: TransportationCamp
-markdown: redcarpet
+markdown: kramdown
 pygments: true
 permalink: /:year/:month/:title/
 paginate: 5

--- a/_posts/2011-02-25-join-a-tour-and-see-transpo-tech-behind-the-scenes.markdown
+++ b/_posts/2011-02-25-join-a-tour-and-see-transpo-tech-behind-the-scenes.markdown
@@ -16,7 +16,7 @@ Signup for these tours opens **Monday 2/28 at 11am ET**. Details below, check ba
 
 TransportationCamp gratefully acknowledges tour support from NYCDOT, the MTA, and Clear Channel. We're especially grateful to the staff who will lead the tours!
 
-(Wonderful time lapse of the Corona Subway depot coming to life at dawn, from [the MTA's YouTube channel](http://www.youtube.com/user/mtainfo)).<!-- more -->
+(Wonderful time lapse of the Corona Subway depot coming to life at dawn, from [the MTA's YouTube channel](http://www.youtube.com/user/mtainfo)).
 
 For all tours, meeting point information will be available once registration opens. Full details will be given to successful applicants. Tour spots are only available to registered TransportationCamp attendees.
 

--- a/_posts/2011-03-03-the-warm-up-conversations-continue.markdown
+++ b/_posts/2011-03-03-the-warm-up-conversations-continue.markdown
@@ -12,8 +12,6 @@ categories:
 
 The TransportationCamp buzz continues, with great discussions [on Twitter](http://twitter.com/#!/search/%23transpo) and [the Topics page](http://transportationcamp.org/topics).  We're especially excited to see longer blog posts --  today's crop includes a discussion of "real time", the future of the smart city, and some reflections on information tech and transportation equality. If you want to participate, [submit to Open Transportation](http://opentransportation.tumblr.com/submit), or let us know that you're blogging elsewhere.
 
- <!-- more -->
-
 
 
 ### [What’s holding up “real time”? Costs and standards.](http://opentransportation.tumblr.com/post/3620907071/whats-holding-up-real-time-costs-and-standards)
@@ -25,10 +23,6 @@ The TransportationCamp buzz continues, with great discussions [on Twitter](http:
 
 
 > From riders to developers to transit agencies, it’s hard to find anyone who wouldn’t agree that we should be pushing for real-time in all forms, and with good reason.  Real-time transit info for riders has all sorts of positive impacts: increased satisfaction, decreased wait times, improved perception of safety, and ultimately more trips made using public transit.  So what’s the hold up?  There are two big issues at play: cost and standards. 
-
-
-
-
 
 ### [There is a battle brewing over the future of the smart city.](http://opentransportation.tumblr.com/post/3620910060/there-is-a-battle-brewing-over-the-future-of-the-smart)
 

--- a/_posts/2011-03-05-a-recap-from-saturday-morning-at-transportationcamp-east.markdown
+++ b/_posts/2011-03-05-a-recap-from-saturday-morning-at-transportationcamp-east.markdown
@@ -21,27 +21,25 @@ The morning started with warm welcomes from NYLS's Beth Noveck and OpenPlans Dir
 Group introductions were the standard "unconference" model:  name, affiliation, three words that describe why you are here. Some examples that demonstrate the range of interests and expertise in the room:
 
 
+  * Sarah Goodyear = "journalism, bicycles, new york"
 
 
-  * Sarah Goodyear =      "journalism, bicycles, new york"
+  * Omar Peters = "I, love, cities"
 
 
-  * Omar Peters = "      I, love, cities"
+  * Adam Greenfield = "open, public, objects"
 
 
-  * Adam Greenfield =      "open, public, objects"
+  * Mike Arrow = "subways, buses, engineer"
 
 
-  * Mike Arrow =      "subways, buses, engineer"
+  * Stuart Strickland = "anything, but, cars"
 
 
-  * Stuart Strickland =      "anything, but, cars"
+  * Liz Paul MTA = "open, payments, transit"
 
 
-  * Liz Paul MTA =      "open, payments, transit"
-
-
-  * Darren Levy =      "free, open, data"
+  * Darren Levy = "free, open, data"
 
 
 Giovanni Carnaroli, Senior Accountable Official for Open Gov, USDOT opened the morning keynotes.  Carnaroli expressed his office's openness to suggestions from the TransportationCamp audience:  "I’m here to listen to you guys, to find out what other data sets you want and need."

--- a/_posts/2011-03-06-nerds-get-down-at-ignite-transpo.markdown
+++ b/_posts/2011-03-06-nerds-get-down-at-ignite-transpo.markdown
@@ -14,24 +14,23 @@ It was a long, stimulating day at TransportationCamp East, but that didn't stop 
 
 [![]({{ site.baseurl }}/assets/uploads/2011/03/IMG_2850.2-1024x768.jpg)]({{ site.baseurl }}/assets/uploads/2011/03/IMG_2850.2.jpg)
 
-Ignite #Transpo hostess Shin-pei Tsay (Transportation Carbon and Deficit Reduction at the Carnegie Endowment   for International Peace) started things off with a warm, jovial welcome and moved directly into the first few speakers:  [Andy Palanisamy](http://www.linkedin.com/in/transportgooru) got things rolling with hilarious immigrant perspectives on the US and transportation in **Coming to America. **
+Ignite #Transpo hostess Shin-pei Tsay (Transportation Carbon and Deficit Reduction at the Carnegie Endowment   for International Peace) started things off with a warm, jovial welcome and moved directly into the first few speakers:  [Andy Palanisamy](http://www.linkedin.com/in/transportgooru) got things rolling with hilarious immigrant perspectives on the US and transportation in **Coming to America**.
 
-Alex Bell reeled the audience in a little by talking about cheaper solutions to real time arrival data with** Not perfect, but good enough? Cheaper solutions to transit problems.**
+Alex Bell reeled the audience in a little by talking about cheaper solutions to real time arrival data with **Not perfect, but good enough? Cheaper solutions to transit problems**.
 
-Then [Francisca Rojas](http://harvard.academia.edu/FranciscaRojas) (below) shared her research on the state of user generated data in transportation agencies across the nation in **Transit Transparency: A Real Time Action Cycle.**
+Then [Francisca Rojas](http://harvard.academia.edu/FranciscaRojas) (below) shared her research on the state of user generated data in transportation agencies across the nation in **Transit Transparency: A Real Time Action Cycle**.
 
 [![]({{ site.baseurl }}/assets/uploads/2011/03/IMG_2883.21-1024x768.jpg)]({{ site.baseurl }}/assets/uploads/2011/03/IMG_2883.21.jpg)
 
-[Marcus Bowman](http://twitter.com/#!/3gmobility) (below) was on next, throwing hilarious random references ([Jet Pack Man](http://www.google.com/images?q=jet+pack+man+yves&hl=en&client=firefox-a&hs=UXv&rls=org.mozilla:en-US:official&prmd=ivns&source=lnms&tbs=isch:1&ei=T6BzTY6QMYqV0QHrm8jFAQ&sa=X&oi=mode_link&ct=mode&cd=2&ved=0CAcQ_AUoAQ&biw=1112&bih=528)!) into an energetic and entertaining argument for harder/better/faster/stronger progress in mobility in **Transportation: Evolution to Revolution.**
+[Marcus Bowman](http://twitter.com/#!/3gmobility) (below) was on next, throwing hilarious random references ([Jet Pack Man](http://www.google.com/images?q=jet+pack+man+yves&hl=en&client=firefox-a&hs=UXv&rls=org.mozilla:en-US:official&prmd=ivns&source=lnms&tbs=isch:1&ei=T6BzTY6QMYqV0QHrm8jFAQ&sa=X&oi=mode_link&ct=mode&cd=2&ved=0CAcQ_AUoAQ&biw=1112&bih=528)!) into an energetic and entertaining argument for harder/better/faster/stronger progress in mobility in **Transportation: Evolution to Revolution**.
 
 [![]({{ site.baseurl }}/assets/uploads/2011/03/IMG_2884-1024x768.jpg)]({{ site.baseurl }}/assets/uploads/2011/03/IMG_2884.jpg)
 
-Ana Bayne (Allegheny County Transit Council) "went factoid" with **What Transit is about and  … What’s market research got to do with it? **Then NYC DOT's Neil Freeman demonstrated his very nimble social media success story, a tumblr blog account of the New York City pothole season in **Making Potholes Cool.**
+Ana Bayne (Allegheny County Transit Council) "went factoid" with **What Transit is about and… What’s market research got to do with it? **Then NYC DOT's Neil Freeman demonstrated his very nimble social media success story, a tumblr blog account of the New York City pothole season in **Making Potholes Cool**.
 
 Transportation engineer and data connoisseur [Chris Pangilinan](http://www.linkedin.com/profile/view?id=17603255&authType=NAME_SEARCH&authToken=7HjO&locale=en_US&srchid=c6302dad-a6fc-4c18-9b2d-bedb5f03858f-0&srchindex=2&srchtotal=11&pvs=ps&pohelp=&goback=.fps_*1_Chris_Pangilinan_*1_*1_*1_*1_*51_*1_Y_*1_*1_*1_false_1_R_true_*2_*2_*2_*2_*2_*2_*2_*2_*2_*2_*2_*2_*2_*2_*2_*2_*2_*2_*2_*2_*2) assaulted current transportation planning, saying it's like "driving with the headlights off."  Chris challenged the developers in the room to make change with **Transforming Transportation in a Sea of Data**.
 
-"Professional futurist" [Garry Golden](http://www.garrygolden.net/) ended the show with lots of David Hasselhoff references in **From Driver to Captain**, bravely suggesting that we channel the Night Rider car a little bit more** **when we envision (and build!) future #transpo systems.** ** (David Hasselhoff?!)**
-**
+"Professional futurist" [Garry Golden](http://www.garrygolden.net/) ended the show with lots of David Hasselhoff references in **From Driver to Captain**, bravely suggesting that we channel the Night Rider car a little bit more **when we envision (and build!) future #transpo systems.** (David Hasselhoff?!)
 
 [![]({{ site.baseurl }}/assets/uploads/2011/03/IMG_2899-1024x768.jpg)]({{ site.baseurl }}/assets/uploads/2011/03/IMG_2899.jpg)
 

--- a/_posts/2011-03-06-sunday-morning-at-transportationcamp-east.markdown
+++ b/_posts/2011-03-06-sunday-morning-at-transportationcamp-east.markdown
@@ -12,7 +12,7 @@ categories:
 
 Sunday's TransportationCamp [program](http://transportationcamp.org/east) got off to a civilized mid-morning start.
 
-Kick-off topics in Session Five ranged from **Networked vehicle systems** (led by [@weeels](http://twitter.com/weeels)) to **Can we do a road pricing system for really cheap with existing tech?**. Georgia Bullen drew a capacity crowd for a **Data vis and policy **session.
+Kick-off topics in Session Five ranged from **Networked vehicle systems** (led by [@weeels](http://twitter.com/weeels)) to **Can we do a road pricing system for really cheap with existing tech?**. Georgia Bullen drew a capacity crowd for a **Data vis and policy** session.
 
 **[![]({{ site.baseurl }}/assets/uploads/2011/03/IMG_2924-1024x768.jpg)]({{ site.baseurl }}/assets/uploads/2011/03/IMG_2924.jpg)**
 

--- a/_posts/2011-03-20-saturday-night-ignition.markdown
+++ b/_posts/2011-03-20-saturday-night-ignition.markdown
@@ -16,6 +16,6 @@ Truly torrential downpour did not stop TransportationCamp West's day one Ignite 
 
 Many thanks again to our MC, Josette Melchor from Gray Area Foundation  for the Arts (below), our [seven great presenters](transportationcamp.org/ignite), and our open bar sponsor, Red  Hat.
 
-[![]({{ site.baseurl }}/assets/uploads/2011/03/IMG_3514-1024x768.jpg)](../wp-content/uploads/2011/03/IMG_3514.jpg)
+[![]({{ site.baseurl }}/assets/uploads/2011/03/IMG_3514-1024x768.jpg)](../assets/uploads/2011/03/IMG_3514.jpg)
 
 Check the Transpocamp Flickr feed for all the [#Transpo Ignite pix](http://www.flickr.com/photos/transportationcamp/sets/72157626184711157/).

--- a/_posts/2012-01-11-code-for-livability-sunday-jan-22.markdown
+++ b/_posts/2012-01-11-code-for-livability-sunday-jan-22.markdown
@@ -15,29 +15,7 @@ If TransportationCamp whets your appetite for unconferences and collaborative pr
 
 > The White House Office of Public Engagement and The Partnership for Sustainable Communities -- U.S. Department of Housing and Urban Development (HUD), the U.S. Department of Transportation (DOT), and the U.S. Environmental Protection Agency (EPA) -- invite you to join us for the Code for Livability on January 22, 2012.   The Code for Livability brings key stakeholders with backgrounds related to livability, housing, transportation and environmental issues together with experts in web development and technology to work on Solutions in REAL Time that can bring sustainability to the forefront of peoples’ everyday lives.
 
-> 
 > When: Sunday, January 22, 2012, 9:00am – 1:00pm
-> 
-> 
-
-> 
-> 
-
-> 
 > Where: American Public Transportation Association. 1666 K Street, NW.  Washington, DC 20006
-> 
-> 
-
-> 
-> 
-
-> 
 > Special Guest:  Chris Vein, Deputy Chief Technology Officer, White House
-> 
-> 
-
-> 
-> 
-
-> 
 > [RSVP by January 19, 2012]( http://c4livabilitydc.eventbrite.com/).

--- a/_posts/2012-01-19-get-ready-for-saturday.markdown
+++ b/_posts/2012-01-19-get-ready-for-saturday.markdown
@@ -17,20 +17,10 @@ For example, here's the section on creating a compelling sticky note - an essent
 
 > Show up at TransportationCamp with your session in mind. Head to the board, grab a sticky note, and describe your session. Don’t be shy about it!  You are interesting and your work is compelling and people will want to hear what you have to share. Your note must include:
 
->
->
-
 >   * Session title
->
-
 >   * Your name
->
-
 >   * What kind of session it is (presentation, brainstorm, Q&A, demos, hacking...)
->
-
 >   * More info about the session -- will it be technical? are you open to co-presenting?
->
 
 It helps if your sticky note is compelling (not just legible). Here are a couple of great examples:
 

--- a/_posts/2013-01-12-live-from-transportationcamp-dc-2013.markdown
+++ b/_posts/2013-01-12-live-from-transportationcamp-dc-2013.markdown
@@ -22,7 +22,7 @@ TransportationCamp DC is underway, with record attendance.
 
 **Transpo Benefit-Cost Analysis**. Room 121.
 
-**Gender and safety on the Delhi Metro. **Room 310.
+**Gender and safety on the Delhi Metro.** Room 310.
 
 **Are we representin'?** Bikes, infrastructure, crowd sourcing, equity, digital divide. Room 311.
 
@@ -93,7 +93,7 @@ TransportationCamp DC is underway, with record attendance.
 
 **OneBusAway for DC** - integrated real-time information. Room 313
 
-**Have faith! **How to diversify your advocacy coalition without pulling your hair out. Room 317
+**Have faith!** How to diversify your advocacy coalition without pulling your hair out. Room 317
 
 **Marketing Transportation.** Brainstorms. Room 318
 
@@ -136,7 +136,7 @@ TransportationCamp DC is underway, with record attendance.
 
 **US Bicycle Routes**. Making the local connection and using the USBR to leverage better local routes. Room 317
 
-**Who is listening? ****Persuasion that worked! tell us about your wins with politicians, decision-makers, businesses and communities that improved transit, ped and driver mobility.**** R**oom 318
+**Who is listening?** Persuasion that worked! tell us about your wins with politicians, decision-makers, businesses and communities that improved transit, ped and driver mobility. Room 318
 
 **Transit for the R. E. S. T.** Retired, Elderly, Suburban, Transit-dependent. Challenges and opportunity. Room 466
 

--- a/_posts/2015-03-20-looking-back.md
+++ b/_posts/2015-03-20-looking-back.md
@@ -9,11 +9,18 @@ categories:
 - Latest News
 ---
 
-The 2015 Transportation Camp in DC was a big success, with 416 people attending from all over the country (and beyond). Our sponsors at [Mobility Lab](http://mobilitylab.org/) have created two videos from interviews that were made during the event:
-<p align=center>
+The 2015 TransportationCamp in DC was a big success, with 416 people
+attending from all over the country (and beyond). Our sponsors at
+[Mobility Lab](http://mobilitylab.org/) have created two videos from
+interviews that were made during the event:
+
+
+<p align="center">
 <iframe width="560" height="315" src="https://www.youtube.com/embed/3SO97RBELmc" frameborder="0" allowfullscreen></iframe>
-<p align=center>
+<br>
 <iframe width="560" height="315" src="https://www.youtube.com/embed/hFs8tKs-Syk" frameborder="0" allowfullscreen></iframe>
-<p>
+</p>
+
+
 And be sure to read Amy Eagleburger's summary, [“Best Conference Ever:” TransportationCamp’s Lab-Like Setting Energizes Attendees](http://mobilitylab.org/2015/01/14/best-conference-ever-transportationcamps-lab-like-setting-energizes-attendees/). If you can't wait for the 2016 Transportion Camp, don't forget about [TransportationCamp NE 2015](http://transportationcamp.org/events/new-england-2015/) coming up April 11.
 

--- a/_posts/2016-02-02-voices-from-2016.md
+++ b/_posts/2016-02-02-voices-from-2016.md
@@ -10,8 +10,12 @@ categories:
 ---
 
 The team at [Mobility Lab](http://mobilitylab.org/) interviewed participants of [TransportationCamp DC 2016](http://transportationcamp.org/events/dc-2016), asking them about the most exciting things they're working on.
-<p align=center>
-<iframe align="center" width="560" height="315" src="https://www.youtube.com/embed/3m8271DtNt0?rel=0" frameborder="0"></iframe>
+
+<p align="center">
+<iframe align="center" width="560" height="315"
+src="https://www.youtube.com/embed/3m8271DtNt0?rel=0"
+frameborder="0"></iframe>
+</p>
 
 Hear from Tim Papandreou, Tien-Tien Chan, Jenny O'Brien, Darren Buck, Todd Litman, Michael Schade,
 Stephanie Dock, Pete Gould, Dennis Leach, Alli Henry, Beverly Scott, Howard Jennings, and Paul Mackie.

--- a/events/california-2015/index.markdown
+++ b/events/california-2015/index.markdown
@@ -28,6 +28,6 @@ If you’re travelling on the day of the event, you can reach Rohnert Park from 
 
 If you need any accommodations to make your trip to TransportationCamp California possible, contact <thomas@trilliumtransit.com> for assistance.
 
-<img src="tcamp-banner.png" width=800 height=400 >
+<img src="tcamp-banner.png" width="800" height="400">
 
 

--- a/events/colorado-2016/index.markdown
+++ b/events/colorado-2016/index.markdown
@@ -16,7 +16,7 @@ discussing and collaborating on innovative solutions to Colorado’s transportat
 
 ### Goal
 
-<img float=right align=right width=192 height=96 src="tcco.jpg">We aim to gather urban planners,
+<img float="right" align="right" width="192" height="96" src="tcco.jpg">We aim to gather urban planners,
 software developers, data scientists, engineers,
 designers, entrepreneurs, students, officials,and innovators for an exciting “un­conference”.
 Unlike a traditional conference, at TransportationCamp the breakout session topics are determined by the participants,
@@ -33,8 +33,10 @@ Happy hour to follow.
 
 TransportationCamp Colorado will be held at [Galvanize Boulder](http://www.galvanize.com/campuses/boulder-west-pearl/),
 1035 Pearl Street, Boulder, CO.
-<p align=center>
+
+<p align="center">
 <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1527.7924568216263!2d-105.28305394332321!3d40.01771847941344!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x876bec26e4137699%3A0xf9d8bd928167d4d5!2s1035+Pearl+St%2C+Boulder%2C+CO+80302!5e0!3m2!1sen!2sus!4v1449775252762" width="680" height="340" frameborder="0" style="border:0" allowfullscreen></iframe>
+</p>
 
 ### Contact Us
 

--- a/events/dc-2013/index.markdown
+++ b/events/dc-2013/index.markdown
@@ -8,7 +8,7 @@ title: Washington DC 2013
 wordpress_id: 1529
 ---
 
-TransportationCamp is returning to Washington DC on January 12, 2013, after a successful event in 2012 ([DC '12](http://transportationcamp.org/dc/)).
+TransportationCamp is returning to Washington DC on January 12, 2013, after a successful event in 2012 ([DC '12](http://transportationcamp.org/dc/)).
 
 
 ### Registration
@@ -28,19 +28,12 @@ We're excited to be hosted by the GMU School of Public Policy, at GMU Founders H
 
 The location is easy to get to:
 
-
-
-
   * Founders Hall is located two blocks east of the Virginia Square Metro Station (Orange Line).
-
-
   * Two Capital Bikeshare stations are also within two blocks, at Virginia Square Metro and at Fairfax Dr/Wilson Blvd.
+  * Metrobus 38B runs from K St, NW and Georgetown.
 
 
-  * Metro bus 38B runs from K St, NW and Georgetown.
-
-
-​Here's more info including [parking and a ](http://transportationcamp.us2.list-manage.com/track/click?u=f737d6aae1136fa999b210fdf&id=7ab72b9baa&e=057c25a61a)[map of the campus](http://info.gmu.edu/Maps/ArlingtonMap12.pdf).
+Here's more info including [parking and a ](http://transportationcamp.us2.list-manage.com/track/click?u=f737d6aae1136fa999b210fdf&id=7ab72b9baa&e=057c25a61a)[map of the campus](http://info.gmu.edu/Maps/ArlingtonMap12.pdf).
 
 
 ### Get ready!

--- a/events/dc-2015/index.markdown
+++ b/events/dc-2015/index.markdown
@@ -43,7 +43,7 @@ We'll be returning this year to GMU Founders Hall, at 3351 Fairfax Drive, Arling
   * There is a [Capital Bikeshare](http://www.capitalbikeshare.com/) station in front of Founders Hall.
   * Metro [bus 38B](http://www.wmata.com/bus/timetables/view.cfm?line=12) runs between Ballston (Virginia) and Farragut Square (DC, via Georgetown).
 
-<iframe align=center src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1552.8558231973786!2d-77.10089523808!3d38.88483864213981!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89b7b6828ba038d9%3A0xdc8b8bb98b169604!2sGeorge+Mason+University-Arlington+Campus!5e0!3m2!1sen!2sus!4v1412725299805" width="640" height="320" frameborder="0" style="border:0"></iframe>
+<iframe align="center" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1552.8558231973786!2d-77.10089523808!3d38.88483864213981!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89b7b6828ba038d9%3A0xdc8b8bb98b169604!2sGeorge+Mason+University-Arlington+Campus!5e0!3m2!1sen!2sus!4v1412725299805" width="640" height="320" frameborder="0" style="border:0"></iframe>
 
 Here's a map of the [Arlington campus](http://info.gmu.edu/Maps/ArlingtonMap14.pdf). 
 

--- a/events/dc-2016/index.markdown
+++ b/events/dc-2016/index.markdown
@@ -41,7 +41,7 @@ The current attendee list is available at [transpo16attendees.pdf](transpo16atte
 
 ### Schedule
 
-<table cellpadding=0 cellspacing=0 border=0 >
+<table cellpadding="0" cellspacing="0" border="0" >
 <tr><td>8:30am - 9:30am</td><td>Doors open; breakfast (sponsor gallery, ground floor)</td></tr>
 <tr><td>9:30am - 9:40am</td><td>Welcome statements (multi-purpose room, ground floor)</td></tr>
 <tr><td>9:40am - 10:50am</td><td>Self-introductions, logistics</td></tr>
@@ -66,24 +66,27 @@ The address is 3351 Fairfax Dr, Arlington, VA 22201. The campus is easy to get t
   * For drivers, the [Founders Hall Parking Garage](http://parking.gmu.edu/arlingtoncampusparking.html)
   has a daily rate of $7 (enter via Kirkwood Rd).
 
-<iframe align=center src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1552.8558231973786!2d-77.10089523808!3d38.88483864213981!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89b7b6828ba038d9%3A0xdc8b8bb98b169604!2sGeorge+Mason+University-Arlington+Campus!5e0!3m2!1sen!2sus!4v1412725299805" width="680" height="340" frameborder="0" style="border:0"></iframe>
-<p></p>
+<iframe align="center" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1552.8558231973786!2d-77.10089523808!3d38.88483864213981!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89b7b6828ba038d9%3A0xdc8b8bb98b169604!2sGeorge+Mason+University-Arlington+Campus!5e0!3m2!1sen!2sus!4v1412725299805" width="680" height="340" frameborder="0" style="border:0"></iframe>
+
 ### Sponsors
 
 TransportationCamp DC 2016 is made possible thanks to our sponsors:
-<p align=center >
-<img src="logo-uber.png"><br>
-[Uber](http://www.uber.com/) - Gold Sponsor
+
+<p align="center" >
+<img src="logo-uber.png"><br> [Uber](http://www.uber.com/) - Gold Sponsor
 </p>
-<p align=center >
-<img width=260 height=100 src="logo-camsys.png"> &nbsp;&nbsp;&nbsp; <img width=260 height=100 src="logo-zipcar.png"><br>
-<img width=260 height=100 src="logo-car2go.png"> &nbsp;&nbsp;&nbsp; <img width=260 height=100 src="logo-lmi.png"><br>
+
+<p align="center">
+<img width="260" height="100" src="logo-camsys.png"> &nbsp;&nbsp;&nbsp; <img width="260" height="100" src="logo-zipcar.png"><br>
+<img width="260" height="100" src="logo-car2go.png"> &nbsp;&nbsp;&nbsp; <img width="260" height="100" src="logo-lmi.png"><br>
 [Cambridge Systematics](http://www.camsys.com/), [Zipcar](http://www.zipcar.com/), [Car2Go](https://www.car2go.com/), [LMI Research Institute](http://www.lmi.org/) - Silver Sponsors
 </p>
-<p align=center >
+
+<p align="center" >
 <img src="logo-lyft.png"> &nbsp;&nbsp;&nbsp; <img src="logo-kimleyhorn.png"> &nbsp;&nbsp;&nbsp; <img src="logo-globesherpa.png"><br>
 [Lyft](http://www.lyft.com/), [Kimley-Horn](http://www.kimley-horn.com/), [GlobeSherpa](http://www.globesherpa.com/) - Bronze Sponsors
 </p>
+
 TransportationCamp DC 2016 is being organized by [Mobility Lab](http://mobilitylab.org/) with help from  
 [TransitCenter](http://transitcenter.org/),
 [Young Professionals in Transportation](http://yptransportation.org/),
@@ -93,8 +96,8 @@ the [Center for Transportation Public-Private Partnership Policy at the George M
 [Institute of Transportation Engineers](http://www.ite.org/), and
 the [Transportation Research Board](http://www.trb.org/) of the [National Academies](http://www.nationalacademies.org/).
 
-<table cellpadding=0 cellspacing=0 border=0 width=100% >
-<tr><td width=100% align=center valign=middle >
+<table cellpadding="0" cellspacing="0" border="0" width="100%" >
+<tr><td width="100%" align="center" valign="middle" >
 <img src="logo-mobilitylab120x100.png"> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <img src="logo-transitcenter.png"> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <img src="logo-ypt.png"> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
@@ -109,7 +112,8 @@ the [Transportation Research Board](http://www.trb.org/) of the [National Academ
 Stay tuned to [@transpocamp](https://twitter.com/transpocamp) (and the [#transpo16](https://twitter.com/search?q=%23transpo16) hashtag)
 for news about this event and other TransportationCamps as they are announced.
 
-<p align=center>
+<p align="center">
 <a href="https://www.flickr.com/photos/mvjantzen/15662555003/" title="TransportationCamp DC 2015"><img src="https://farm8.staticflickr.com/7496/15662555003_46ee1c9fa6_m.jpg" width="198" height="132" alt="TransportationCamp DC 2015"></a>
 <a href="https://www.flickr.com/photos/mvjantzen/15663480523/" title="The Board"><img src="https://farm9.staticflickr.com/8641/15663480523_4180b79746_m.jpg" width="198" height="132" alt="TransportationCamp DC 2015"></a>
 <a href="https://www.flickr.com/photos/mvjantzen/16281595951/" title="Founders Hall"><img src="https://farm8.staticflickr.com/7512/16281595951_b0d6039a92_m.jpg" width="198" height="132" alt="TransportationCamp DC 2015"></a>
+</p>

--- a/events/dc/.#index.markdown
+++ b/events/dc/.#index.markdown
@@ -1,0 +1,1 @@
+kurt@Kurt-Raschke.local.28857

--- a/events/dc/index.markdown
+++ b/events/dc/index.markdown
@@ -8,7 +8,7 @@ title: Washington DC 2012
 wordpress_id: 1274
 ---
 
-TransportationCamp is coming to Washington DC on **January 21, 2012, **after two successful TransportationCamp events in 2011 ([East](http://transportationcamp.org/east/) and [West](http://transportationcamp.org/west/)).
+TransportationCamp is coming to Washington DC on  **January 21, 2012**, after two successful TransportationCamp events in 2011 ([East](http://transportationcamp.org/east/) and [West](http://transportationcamp.org/west/)).
 
 
 ### Registration

--- a/events/east/index.markdown
+++ b/events/east/index.markdown
@@ -12,10 +12,6 @@ TransportationCamp East was held in **New York City** on **Saturday March 5 and 
 
 We'd like to thank the group of [partners and advisors](http://transportationcamp.org/partners-and-advisors/) for their support in organizing this event.
 
-Jump to: Friday Schedule | Saturday Schedule | Sunday Schedule | Sponsors
-
-
-
 
 ## Schedule
 
@@ -39,9 +35,6 @@ Afternoon tours, [details here](http://transportationcamp.org/2011/02/join-a-tou
 
 ## Saturday March 5th
 
-
-
-
 #### 8am
 
 
@@ -52,9 +45,6 @@ Afternoon tours, [details here](http://transportationcamp.org/2011/02/join-a-tou
 
 
 **Morning program**
-
-
-
 
   * Welcome & introductions.
 
@@ -75,54 +65,45 @@ Afternoon tours, [details here](http://transportationcamp.org/2011/02/join-a-tou
 
 #### 11:15am-12pm
 
-
 **Session #1**. Concurrent participant-led sessions.
 
 
 ##### FacLounge
-
 
 **Behavior Change!** for transit. Led by Drew Snyder.
 
 
 ##### 303
 
-
 **How to Plan Transit Trips Using a Combination of Google Transit & Real-time Info Across Systems.** Led by Holly Parker, Yale, and Dominique from TransLoc.
 
 
 ##### 320
-
 
 **DIY/Grassroots Advocacy** - to support/give feedback on transit at a contentious time.
 
 
 ##### 504
 
-
 **Q&A with Giovanni Carnaroli, Peter Appel, and Charlie Monheim**
 
 
 ##### 505
-
 
 **Open Payments in Transit, Taxis, Bike Sharing, etc…**. Led by Candy.
 
 
 ##### 520
 
-
 **Remove PARKING, Increase Road Capacity**. Led by [@weeels](http://twitter.com/weeels).
 
 
 ##### 403
 
-
 **Games to Enhance the Transit Experience**
 
 
 ##### 5th Fl Cafe
-
 
 **How to Get Localized Discussions About What's Happening on Your Subway Line, Station, Railroad Line, Bus Route**
 
@@ -135,136 +116,110 @@ Afternoon tours, [details here](http://transportationcamp.org/2011/02/join-a-tou
 
 #### 12:15pm
 
-
-** Luncheon program**
-
-
-
+**Luncheon program**
 
   * Remarks from **Chris Vein**, Deputy United States Chief Technology Officer for Government Innovation, Office of Science and Technology Policy.
-
-
-  * Remarks from** Brad Burnham**, Partner, Union Square Ventures.
+  * Remarks from **Brad Burnham**, Partner, Union Square Ventures.
 
 
 
 
 #### 1:45pm-2:45pm
 
-
 **Session #2**. Concurrent participant-led sessions.
 
 
 ##### FacLounge
-
 
 **Getting Non-Riders to Use Public Transit** Identifying info deficits, overcoming objections, specialized timetables. Discussion, led by [@bus15237](http://twitter.com/bus15237), @[transitguru](http://twitter.com/transitguru).
 
 
 ##### 303
 
-
 **Social Media for Transportation** Info delivery, public transportation, public relations, networking/knowledge sharing.
 
 
 ##### 320
-
 
 **Q&A with Chris Vein, US Deputy CTO for Government Innovation, and Brad Burnham, Partner, Union Square Ventures**
 
 
 ##### 504
 
-
 **Revenues to fund transportation needs** Highway trust fund trends and challenges, documented infrastructure needs, transition to mileage-based user fee, corresponding deployment of technology. With Joung Lee, AASHTO, and Greg Dierkers, NGA.
 
 
 ##### 505
-
 
 **Open Source Software for Small–Medium Transit Agencies** Dispatch, route planning, trip planner, bus tracker, etc. Discussion led by Adam Sherson.
 
 
 ##### 520
 
-
 **Taxi App Pageant** with NYC TLC and Wheeels, Cabulous, Taxi Magic, Cab Corner, and Fare Share.
 
 
 ##### 403
-
 
 **How to Build a successful Planning Blog** Presentation by Greater Greater Washington.
 
 
 ##### 5th Fl Cafe
 
-
 **Shared Transit -> Shared Cars -> Shared Bikes -> Shared ???** What's next in sharing? What tech/apps can we use? Discussion with Ari Ofsevit.
 
 
 ##### Basement
-
 
 **Creating a New Business Model for Selling Integrated Mobility**. Discussion, with Sue Zielinski and Dwight Mengel.
 
 
 #### 3pm-4pm
 
-
 **Session #3**. Concurrent participant-led sessions
 
 
 ##### FacLounge
-
 
 **Open511** Standards for traffic/transit, conditions, API for reporting transpo issues (e.g. accidents), data routing and aggregation for transit schedules, automatic discovery of regional GTFS. Discussion led by Phil Ashlock.
 
 
 ##### 303
 
-
 **How to Collaborate with Government to Make Technology & Data the Foundation of Transport** Discussion led by Chris P, USDOT.
 
 
 ##### 320
-
 
 **Mobility, access, experience, transmobility: What? How? Why? When?** with Adam Greenfield & the UrbanScale Crew, Sue Zielinski, Ana Baye, Greater Greater Washington, Eric Fidler, Eric Weber, Marcus Bowman.
 
 
 ##### 504
 
-
 **Subway Signaling, Train Tracking & RT Customer Info on the 1-6 lines**. Discussion, led by Mike Frumin, MTA.
 
 
 ##### 505
-
 
 **Fixing the Great Mistake… Reducing Car Traffic in NYC by 90% in 20 Years (10?)**. Presentation and discussion, led by Mark Gorton.
 
 
 ##### 520
 
-
 **Open Taxi Access: San Francisco Innovation or Hippie Dream?**
 
 
 ##### 403
-
 
 **What the hell is a smart street?** Presentation, with Vincent Riscica, ARUP and Phil Carter, ARUP.
 
 
 ##### 5th Fl Cafe
 
-
 **Sustaining Collaboration Between Civic Technologists & Public Organizations** Public good - from technologists and government point of view; cultural barriers for collaboration; strategies for collaboration.
 
 
 ##### Basement
-
 
 **Efficient Creation of Stylized Transit Maps (demo of new Transit Sketchpad)**. Demo of new "transit sketchpad" software with David Emory, discussion of potential for auto-generation from GTFS, etc.
 
@@ -274,54 +229,39 @@ Afternoon tours, [details here](http://transportationcamp.org/2011/02/join-a-tou
 
 **Session #4**. Concurrent participant-led sessions.
 
-
 ##### FacLounge
-
 
 **Carpooling for salespeople** Shared transportation among vendors calling on retail locations. With broadwayhistory.
 
-
 ##### 303
-
 
 **University roles in advancing all this!** Universities connecting with reality, feeding the next generation. Research education, tech transfer. Discussion, with Sue Zielinski and Molly.
 
-
 ##### 504
-
 
 **Open Data and Apps for planning and civic engagement.** How? What?. Discussion with Georgia Bullen.
 
 
 ##### 505
 
-
 **Hiring and Getting Hired.** Organizations with open positions and potential employees networking, featuring OpenPlans, USDOT, others and you.
-
 
 ##### 520
 
-
 **Social Bicycles** Using wireless tech to enhance personal mobility. Discussion, led by Ryan Rzepecki.
-
 
 ##### 403
 
-
 **Designing transit service to meet demand.** System design based on trip generators, ped/bike paths, etc. Discussion, led by [@bus15237](http://twitter.com/bus15237), @[transitguru](http://twitter.com/transitguru), Ana Bayne.
-
 
 ##### Basement
 
-
 **Beyond the Countdown Clock...** A Q&A session about OpenPlan's design competition. Get your questions answered, with Jeff Maki.
-
 
 #### 5:30pm
 
 
 **Closing remarks** In the evening, make your own plans for dinner, or join us at a #transpo group reservation nearby.
-
 
 #### 8pm
 
@@ -330,9 +270,6 @@ Afternoon tours, [details here](http://transportationcamp.org/2011/02/join-a-tou
 
 
 ## Sunday March 6th
-
-
-
 
 
 #### 9:30am
@@ -533,23 +470,20 @@ Waze is a social mobile application that enables drivers to build and use real-t
 [![]({{ site.baseurl }}/assets/uploads/2010/12/3gmobilitylogo.jpg)](http://www.3gmobility.ws/)
 3G Mobility promotes the next generation of transportation, encouraging faster, ecological, cost-effective grassroots solutions
 through social media publishing, strategic consulting, and innovative research.
-** **
+
 
 **Tour sponsors:**
-
 
 [![]({{ site.baseurl }}/assets/uploads/2010/12/mtasymbolpms286.jpg)]({{ site.baseurl }}/assets/uploads/2010/12/mtasymbolpms286.jpg)
 
 
-[![]({{ site.baseurl }}/assets/uploads/2010/12/TTN1-300x92.jpg)]({{ site.baseurl }}/assets/uploads/2010/12/TTN1.jpg)** **
-** **
+[![]({{ site.baseurl }}/assets/uploads/2010/12/TTN1-300x92.jpg)]({{ site.baseurl }}/assets/uploads/2010/12/TTN1.jpg)
 
 **Event supporters & partners:**
-**[![]({{ site.baseurl }}/assets/uploads/2010/12/spur-logo_bw.jpg)]({{ site.baseurl }}/assets/uploads/2010/12/spur-logo_bw.jpg)
-**
-**[![](https://evbdn.eventbrite.com/s3-s3/eventlogos/9246459/mediapartnersaslogo960x2001.jpg)](http://secondavenuesagas.com/)**
-**
-**
+
+* [![]({{ site.baseurl }}/assets/uploads/2010/12/spur-logo_bw.jpg)]({{ site.baseurl }}/assets/uploads/2010/12/spur-logo_bw.jpg)
+* [![](https://evbdn.eventbrite.com/s3-s3/eventlogos/9246459/mediapartnersaslogo960x2001.jpg)](http://secondavenuesagas.com/)
+
 [![]({{ site.baseurl }}/assets/uploads/2010/12/LOGOTYPE_4-300x47.jpg)]({{ site.baseurl }}/assets/uploads/2010/12/LOGOTYPE_4.jpg)
 [![]({{ site.baseurl }}/assets/uploads/2010/12/blinktag-logo.jpg)](http://blinktag.com/)
 [![]({{ site.baseurl }}/assets/uploads/2010/12/CityCampSF.png)](http://citycampsf.govfresh.com/)

--- a/events/midwest-2016/index.markdown
+++ b/events/midwest-2016/index.markdown
@@ -12,8 +12,7 @@ Time: TBD<br>
 Location: [Mid-America Regional Council](http://www.marc.org/), 600 Broadway, Kansas City, MO<br>
 Price: TBD<br>
 Sponsors: TBD
-<p>
-<img width=680 height=249 src="tcmw.png">
-<p>
+
+<img width="680" height="249" src="tcmw.png">
+
 <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3096.0215698409015!2d-94.59065668464346!3d39.10597907953888!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x87c0f0f5fe2e28b3%3A0x26ea28b5f3253b67!2s600+Broadway+Blvd%2C+Kansas+City%2C+MO+64105!5e0!3m2!1sen!2sus!4v1449290972668" width="680" height="340" frameborder="0" style="border:0" allowfullscreen></iframe>
-<p></p>

--- a/events/new-england-2015/index.markdown
+++ b/events/new-england-2015/index.markdown
@@ -8,13 +8,13 @@ title: TransportationCamp NE 2015
 wordpress_id: 1623
 published: true
 ---
-<a href="bFD0ljslwL.jpeg"><img src="bFD0ljslwLsmall.jpeg" width=241 height=160 align=right ></a>The 2nd Annual TransportationCamp New England will be held on Saturday, April 11, 2015. 
+<a href="bFD0ljslwL.jpeg"><img src="bFD0ljslwLsmall.jpeg" width="241" height="160" align="right" ></a>The 2nd Annual TransportationCamp New England will be held on Saturday, April 11, 2015. 
 
 Following on the success of last year's event, TransportationCamp New England 2015 will continue to foster open conversation and collaboration between all parties interested in mobility and the radical changes the near-future promises in transportation.
 
 Our goal is to assemble planners, dreamers, programmers, students, and professionals for an exciting day of "un-conferencing." Unlike a traditional conference, the specific session topics are determined by participants, which provides each attendee an opportunity to lead and shape the event. Therefore, we want to see what you are doing; we want to ask how it will impact our lives; and we want to help you to find answers.
 
-<a href="x1DAoy1T8V.jpeg"><img src="x1DAoy1T8Vsmall.jpeg" width=241 height=160 align=right ></a>Some of this year’s session topics will included:
+<a href="x1DAoy1T8V.jpeg"><img src="x1DAoy1T8Vsmall.jpeg" width="241" height="160" align="right" ></a>Some of this year’s session topics will included:
 
 * Bike share applications and technology
 * Open source data and standards
@@ -25,7 +25,7 @@ Our goal is to assemble planners, dreamers, programmers, students, and professio
 * Improving mobility in Boston (and beyond!)
 * Transformative trends in transportation
 
-<img width=140 height=160 src="Secretary_Davey140x160.jpg" align=right title="Richard Davey">We are pleased to announce that the keynote speaker at this year's event will be Richard Davey, former Massachusetts Secretary of Transportation and current CEO of [Boston 2024](http://www.2024boston.org/), the nonprofit organization working to bring the 2024 Summer Olympic Games to Boston. Prior to these roles, he also served as General Manager for both the Massachusetts Bay Transportation Authority and the Massachusetts Bay Commuter Railroad Company.
+<img width="140" height="160" src="Secretary_Davey140x160.jpg" align="right" title="Richard Davey">We are pleased to announce that the keynote speaker at this year's event will be Richard Davey, former Massachusetts Secretary of Transportation and current CEO of [Boston 2024](http://www.2024boston.org/), the nonprofit organization working to bring the 2024 Summer Olympic Games to Boston. Prior to these roles, he also served as General Manager for both the Massachusetts Bay Transportation Authority and the Massachusetts Bay Commuter Railroad Company.
 
 Register [here](http://www.eventbrite.com/e/transportationcamp-new-england-2015-tickets-13577902873) for TransportationCamp New England 2015!
 
@@ -35,7 +35,7 @@ If you are interested becoming a sponsor of TransportationCamp New England 2015,
 
 ###Schedule and Events
 
-<a href="cltTonUej9.jpeg"><img src="cltTonUej9small.jpeg" width=120 height=160 align=right ></a> TransportationCamp New England 2015 will be hosted by MIT and the [MIT Transportation Club](http://t-club.mit.edu/) at:
+<a href="cltTonUej9.jpeg"><img src="cltTonUej9small.jpeg" width="120" height="160" align="right" ></a> TransportationCamp New England 2015 will be hosted by MIT and the [MIT Transportation Club](http://t-club.mit.edu/) at:
 
 > Stata Center, Main Floor<br>
 > 32 Vassar Street<br>
@@ -55,11 +55,11 @@ The [Young Professionals in Transportation (YPT) Boston Chapter](http://www.yptb
 
 Many thanks to our sponsors:
 
-<img src="sponsor-airsage.png" width=160 height=160 > &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <img src="sponsor-bridj.jpg" width=160 height=160 ><br>
-<img src="sponsor-neite.png" width=160 height=80 > <img src="sponsor-zipcar.png" width=160 height=80 > <img src="sponsor-iBiz.png" width=160 height=80 ><br><img src="sponsor-Kinisi.png" width=120 height=120 ><br>
-<img src="sponsor-ecolane.png" width=120 height=120 > <img src="sponsor-cartodb.png" width=200 height=80 >   
+<img src="sponsor-airsage.png" width="160" height="160" > &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <img src="sponsor-bridj.jpg" width="160" height="160" ><br>
+<img src="sponsor-neite.png" width="160" height="80" > <img src="sponsor-zipcar.png" width="160" height="80" > <img src="sponsor-iBiz.png" width="160" height="80" ><br><img src="sponsor-Kinisi.png" width="120" height="120" ><br>
+<img src="sponsor-ecolane.png" width="120" height="120" > <img src="sponsor-cartodb.png" width="200" height="80" >   
 
 TransportationCamp New England 2015 is organized by Cambridge Systematics, in partnership with Mobility Lab, MIT, and the Boston Chapter of Young Professionals in Transportation.
 
-<img src="organizer-camsys.png" width=494 height=120 ><br>
-<img src="organizer-mit.png" width=167 height=86 > &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <img src="organizer-MobilityLab.png" width=120 height=120 > &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <img src="organizer-ypt.png" width=120 height=120 >
+<img src="organizer-camsys.png" width="494" height="120" ><br>
+<img src="organizer-mit.png" width="167" height="86" > &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <img src="organizer-MobilityLab.png" width="120" height="120" > &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <img src="organizer-ypt.png" width="120" height="120" >

--- a/events/new-england-2016/index.markdown
+++ b/events/new-england-2016/index.markdown
@@ -23,7 +23,7 @@ TransportationCamp New England 2016 will be hosted on the MIT campus at the Stat
 
 <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2948.103113345732!2d-71.09250915653865!3d42.361641718433624!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89e370a95d3025a9%3A0xb1de557289ff6bbe!2sRay+and+Maria+Stata+Center%2C+Cambridge%2C+MA+02142!5e0!3m2!1sen!2sus!4v1452117338124" width="600" height="450" frameborder="0" style="border:0" allowfullscreen></iframe>
 
-Located two blocks west of the Kendall T-Station (Red Line) and between several garages, the Stata Center is easily accessible by car or public transit, parking information and directions from the T are available [here](http://www.gbcacm.org/venues/cambridge/mit-building-32-stata-center.html).
+Located two blocks west of the Kendall T station (Red Line) and between several garages, the Stata Center is easily accessible by car or public transit, parking information and directions from the T are available [here](http://www.gbcacm.org/venues/cambridge/mit-building-32-stata-center.html).
 
 ###Registration
 Registration for TransportationCamp NE 2016 is now open! Please [Click Here](https://www.eventbrite.com/e/transportationcamp-new-england-2016-tickets-19296075080) to register. If you have any questions, reach out at <TranspoCamp@camsys.com> or [@TranspoCampNE](https://twitter.com/TranspoCampNE). You can also like us on [Facebook](https://www.facebook.com/pages/TransportationCamp-New-England/219391578269518).
@@ -32,15 +32,17 @@ _**Media and Sponsorship Inquiries:** Please contact <TranspoCamp@camsys.com>._
 
 ###Sponsors
 
-####Lunch Sponsors
+#### Lunch Sponsors
 
 <table align="center">
 <tr>
 <td style="vertical-align: center;"><a href="http://www.bridj.com/"><img src="hosts/sponsor-Bridj.jpg" height="125" width="125" alt="Bridj"></a></td>
-<tr>
+</tr>
 </table>
 
-####Breakfast Sponsors
+
+#### Breakfast Sponsors
+
 <table align="center">
 <tr>
 <td style="vertical-align: center;"><a href="http://www.ecolane.com/"><img src="hosts/sponsor-ecolane.png" height="86" width="200" alt="Ecolane"></a></td>
@@ -49,6 +51,7 @@ _**Media and Sponsorship Inquiries:** Please contact <TranspoCamp@camsys.com>._
 </table>
 
 ####With Assistance From
+
 <table align="center">
 <tr>
 <td style="vertical-align: center;"><a href="http://neite.org/"><img src="hosts/NEITE-logo_round.png" height="125" width="125" alt="neite"></a></td>
@@ -58,6 +61,7 @@ _**Media and Sponsorship Inquiries:** Please contact <TranspoCamp@camsys.com>._
 </table>
 
 ###Hosts
+
 TransportationCamp New England 2016 is organized by Cambridge Systematics, in partnership with Mobility Lab, MIT, and the Boston Chapter of Young Professionals in Transportation.
 
 <table align="center">

--- a/events/nyc-2015/index.markdown
+++ b/events/nyc-2015/index.markdown
@@ -27,6 +27,7 @@ and we want to help you to find answers.
 ### Venue
 
 TransportationCamp NYC will be held at City College of New York in Shepard Hall (160 Convent Avenue, New York, NY 10031, at the intersection of Convent Avenue and W 140th St., close to the 1, A, C, and D trains).
+
 <p align="center">
 <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3107.8048111647026!2d-73.95016290760027!3d40.82021094185493!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0000000000000000%3A0x63248bb077f4f293!2sShepard+Hall!5e0!3m2!1sen!2sus!4v1439503246663" width="600" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
 </p>

--- a/events/san-francisco-bay-area-2013/index.markdown
+++ b/events/san-francisco-bay-area-2013/index.markdown
@@ -16,114 +16,42 @@ TransportationCamp is returning to the San Francisco Bay Area on November 16, 
 
 ## Keynote Speakers
 
-
-** ****Ed Reiskin**, Director of Transportation, San Francisco Municipal Transportation Agency
-
-
-
-
+**Ed Reiskin**, Director of Transportation, San Francisco Municipal Transportation Agency
 
 ![Ed Reiskin](https://evbdn.eventbrite.com/s3-s3/eventlogos/25150489/130326154edreiskin.jpg)
 
-
-
-
 **Kevin Novak**, Senior Data Scientist, Uber
-
-
-
 
 ![Kevin Novak](https://evbdn.eventbrite.com/s3-s3/eventlogos/25150489/kevin2bnovak42499193164o.jpg)
 
-
-
-
 **Michal Migurski**, Chief Technology Officer, Code for America
-
-
-
 
 ![Michal Migurski](https://evbdn.eventbrite.com/s3-s3/eventlogos/25150489/mmigurski.jpg)
 
-
-
-
-
-
-
-
 ## Sponsors
-
-
-
-
 Thank you to OpenPlans for organizing the TransportationCamp series!
-
-
-
 
 [![OpenPlans logo](http://wayback.theslowhunch.net/wp-content/uploads/2010/04/OpenPlans-logo-042010.png)](http://openplans.org/)
 
-
-
-
 Thank you to our supporters and sponsors for making this event possible!
 
-
-
-
 **Principal Sponsors**
-
-
-
 
 [![University of California, Berkeley Seal](http://taflab.berkeley.edu/ME245_Oceanic_Atmospheric_Waves_files/berkeley_seal.gif)](http://www.berkeley.edu/index.html) [![Young Professionals in Transportation logo](https://evbdn.eventbrite.com/s3-s3/eventlogos/25150489/yptsfbaylogo.png)](http://yptransportation.org/chapters/yptsfbay/)
 
 
-
-
 University of California Berkeley Department of City and Regional Planning
-
-
-
 
 University of California Transportation Center
 
 
-
-
-
-
-
-
-
-
 **Supporting Sponsors**
-
-
-
 
 [![Iteris Logo](https://evbdn.eventbrite.com/s3-s3/eventlogos/25150489/iteris.jpg)](http://www.iteris.com/) [![Fehr and Peers logo](https://evbdn.eventbrite.com/s3-s3/eventlogos/25150489/fehrpeers.jpg)](http://www.fehrandpeers.com/)
 
-
-
-
-
-
-
 [![Caltrans Seal](http://www.dot.ca.gov/images/ct_logo_trans.gif)](http://www.dot.ca.gov/) [![Transportation Management Association of San Francisco](http://www.tmasfconnects.org/images/tmasf-logo.png)](http://www.tmasfconnects.org/)
 
-
-
-
-
-
-
 Caltrans (non-financial supporter)
-
-
-
-
 
 # Event Notes
 
@@ -132,70 +60,26 @@ Plan your sessions and review session notes at the official [Google Docs folder 
 
 Keep up with the conversation with #TranspoWest
 
-
-
-
-
 ## Event Schedule
-
-
-
 
 Saturday, November 16
 
-
-
-
 8:00 AM - Registration, breakfast, networking
-
-
-
 
 9:00 AM - Introductions
 
-
-
-
 10:00 AM - Keynote speakers
-
-
-
 
 11:00 AM - Break, agendizing, networking
 
-
-
-
 11:15 AM - Session Block 1 (multiple sessions in different rooms)
-
-
-
 
 12:15 PM - Lunch and more agendizing
 
-
-
-
 1:15 PM to 2:15 PM - Session Block 2
-
-
-
 
 2:30 PM to 3:30 PM - Session Block 3
 
-
-
-
 3:45 PM to 4:45 PM - Session Block 4
 
-
-
-
 4:45 PM - Adjourn to happy hour at [Freehouse](http://berkeleyfreehouse.com/), just across the street from Wurster Hall (2700 Bancroft Way)
-
-
-
-
-
-
-

--- a/events/south/index.markdown
+++ b/events/south/index.markdown
@@ -42,16 +42,10 @@ Media/blog coverage:
 
   * Progressive Transit: [Education, debates, demos, and discussion at Transportation Camp South](http://progressivetransit.wordpress.com/2013/02/12/education-debates-demos-and-discussion-at-transportation-camp-south/)
 
-
-
-
-
-
-
 ### Sponsors & Partners
 
 
-TransportationCamp is a project of **[OpenPlans](http://openplans.org/)**. TransportationCamp South is sponsored by the **[Georgia Tech University Transportation Center](http://www.utc.gatech.edu/)**, [**Knight Foundation**](http://www.knightfoundation.org/), [**RideCell**](http://ridecell.com/), **[InstantCab](http://instantcab.com/)**, [**Cambridge Systematics**](http://www.camsys.com/), **[Zipcar](http://www.zipcar.com/)**, and the **[Georgia Chapter of the Sierra Club](http://georgia.sierraclub.org/)**. Organizers for the 2013 event include the **[Georgia Tech Urban Transportation Information Lab](http://watkins.ce.gatech.edu/)**,** ****[Citizens for Progressive Transit](http://www.cfpt.org/)**, and **[Imag](http://www.imagineatlanta.com/)****[ine Atlanta](http://www.imagineatlanta.com/)**.
+TransportationCamp is a project of **[OpenPlans](http://openplans.org/)**. TransportationCamp South is sponsored by the **[Georgia Tech University Transportation Center](http://www.utc.gatech.edu/)**, [**Knight Foundation**](http://www.knightfoundation.org/), [**RideCell**](http://ridecell.com/), **[InstantCab](http://instantcab.com/)**, [**Cambridge Systematics**](http://www.camsys.com/), **[Zipcar](http://www.zipcar.com/)**, and the **[Georgia Chapter of the Sierra Club](http://georgia.sierraclub.org/)**. Organizers for the 2013 event include the **[Georgia Tech Urban Transportation Information Lab](http://watkins.ce.gatech.edu/)**, **[Citizens for Progressive Transit](http://www.cfpt.org/)**, and **[Imagine Atlanta](http://www.imagineatlanta.com/)**.
 
 ![](http://shared.cfpt.org/files/tcs_sponsors.png)
 

--- a/events/texas-2016/index.markdown
+++ b/events/texas-2016/index.markdown
@@ -17,8 +17,10 @@ the [ASCE International Conference on Transportation and Development’s Spring 
 in Houston, Texas. By hosting TransportationCamp at their semi-annual conference, YPT and ASCE
 are helping to create a unique TransportationCamp atmosphere, where technologists, transportation advocates,
 and users can come together in open conversation with the operators of Texas’ transportation providers.
-<p align=center >
+
+<p align="center" >
 <img src="skyline.png" width=550 height=300 >
+</p>
 
 Though it will take place during a conference,
 the event will be run as a standard “unconference” — sessions will be proposed on the day of the event,
@@ -30,5 +32,7 @@ Texas beginning at 10 AM on June 26, 2016 (coffee and networking begin at 9 AM).
 Coffee will be included in the registration fee of $25, but guests will be expected to provide lunch on their own.
 
 Registration is now open, at [asce-ictd.org/transportationcamp](http://www.asce-ictd.org/transportationcamp/).
-<p align=center >
+
+<p align="center" >
 <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d13854.26501199385!2d-95.4592956!3d29.76126390000002!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x855269a9c60f8290!2sOmni+Houston+Hotel!5e0!3m2!1sen!2sus!4v1448252126841" width="550" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
+</p>

--- a/events/west/index.markdown
+++ b/events/west/index.markdown
@@ -12,10 +12,6 @@ TransportationCamp East was held in **San Francisco **on **Saturday March 19 and
 
 We'd like to thank the group of [partners and advisors](http://transportationcamp.org/partners-and-advisors/) for their support in organizing this event.
 
-Jump to: Friday Schedule | Saturday Schedule | Ignite | Sunday Schedule | Sponsors
-
-
-
 
 ## Schedule
 


### PR DESCRIPTION
This PR implements a range of Markdown and HTML syntax fixes in preparation for changing our Markdown renderer to Kramdown.  Some notes coming out of this process:
- Yes, you can still intermingle HTML and Markdown, _but_ your HTML must be _scrupulously_ clean—that means attribute values _must_ be quoted and tags _must_ be validly nested and closed.
- Blocks of HTML should be set off with a blank line before and after.
- Straight Markdown syntax should be preferred over interspersed HTML unless there is simply no way to express something in Markdown.
- Many of the older pages, especially those converted from WordPress, still have a lot of janky markup, broken links, broken images, etc.  I have done some minor cleanup, but really there needs to be a more comprehensive effort.
