### PR TITLE
Correct markdown for TCNE23 additions

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -455,5 +455,5 @@
 - title: New England 2023
   date: 2023-10-07 23:59:59
   url: /events/new-england-2023
-  register_url: [Eventbrite url]
+  register_url:
   background_img: ne-2023.jpg

--- a/events/new-england-2023/index.markdown
+++ b/events/new-england-2023/index.markdown
@@ -7,12 +7,14 @@ slug: "new-england-2023"
 title: TransportationCamp NE 2023
 published: true
 logo: Header-Image_website.png
-logo-alt: “TransportationCamp New England 2023: October 7 at MIT Stata Center”
+logo-alt: "TransportationCamp New England 2023: October 7 at MIT Stata Center"
 hide-title: true
 ---
 
 
-<span style="color: #FF6600;">###TransportationCamp New England is back!</span>
+<span style="color: #FF6600;">
+### TransportationCamp New England is back!
+</span>
 
 After a 3 year hiatus, we return in-person for New England’s 6th annual camp on Saturday, October 7th at the [MIT Stata Center](https://www.google.com/maps/dir//Stata+Center,+32+Vassar+St,+Cambridge,+MA+02139/@42.3616134,-71.0932104,17z/data=!4m18!1m8!3m7!1s0x89e370a95d3025a9:0xb1de557289ff6bbe!2sStata+Center,+32+Vassar+St,+Cambridge,+MA+02139!3b1!8m2!3d42.3616095!4d-71.0906355!16zL20vMDEyamZ2!4m8!1m0!1m5!1m1!1s0x89e370a95d3025a9:0xb1de557289ff6bbe!2m2!1d-71.0906355!2d42.3616095!3e3?entry=ttu)! Join us to be a part of the conversation on all topics of mobility in this open and inclusive event.
 


### PR DESCRIPTION
- Quotation marks in page markdown were incorrect, copied from draft text in Google Docs.
- registration URL not ready yet, was accidentally left in events page markdown update for TCNE23
- header in TCNE23 markdown missing a space